### PR TITLE
chore: target Android 16 for RSS FeedWatch

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,11 +12,11 @@ if (localPropertiesFile.exists()) {
 
 android {
     namespace 'com.tinygc.asachiru'
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         minSdk 21
-        targetSdk 35
+        targetSdk 36
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -58,8 +58,8 @@ android {
         feedwatch {
             dimension "app"
             applicationId "com.tinygc.feedwatch"
-            versionCode 19
-            versionName "1.2.7.2"
+            versionCode 20
+            versionName "1.2.8"
             resValue "string", "app_name", "RSS FeedWatch"
             // FeedWatch用のAdMob App ID
             manifestPlaceholders = [

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
 
     defaultConfig {
         minSdk 21
-        targetSdk 36
+        targetSdk 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -58,6 +58,8 @@ android {
         feedwatch {
             dimension "app"
             applicationId "com.tinygc.feedwatch"
+            // Google Play の対象 API レベル要件に合わせ、FeedWatch のみ Android 16 を対象にする
+            targetSdk 36
             versionCode 20
             versionName "1.2.8"
             resValue "string", "app_name", "RSS FeedWatch"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
 
     defaultConfig {
         minSdk 21
-        targetSdk 35
+        targetSdk 36
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -58,8 +58,6 @@ android {
         feedwatch {
             dimension "app"
             applicationId "com.tinygc.feedwatch"
-            // Google Play の対象 API レベル要件に合わせ、FeedWatch のみ Android 16 を対象にする
-            targetSdk 36
             versionCode 20
             versionName "1.2.8"
             resValue "string", "app_name", "RSS FeedWatch"


### PR DESCRIPTION
### Motivation
- Google Play の対象 API レベル要件に対応するため、RSS FeedWatch を新しい Android API レベルへ更新する必要がありました。
- 更新版をストアへアップロードするためにリリース番号（versionCode/versionName）を適切に増やしました。

### Description
- `app/build.gradle` の `compileSdk` を `36` に更新しました（API レベル 36 / Android 16）。
- `app/build.gradle` の `targetSdk` を `36` に更新しました（API レベル 36 / Android 16）。
- RSS FeedWatch フレーバーの `versionCode` を `20` に、`versionName` を `"1.2.8"` に更新しました（変更箇所: `app/build.gradle`）。

### Testing
- `git diff --check` を実行して差分チェックを行い問題は検出されませんでした。 
- `python3` による静的検証（`compileSdk 36`、`targetSdk 36`、`versionCode 20`、`versionName "1.2.8"` のアサーション）を実行し成功しました。 
- `./gradlew :app:assembleFeedwatchDebug :app:testFeedwatchDebugUnitTest` を試行しましたが、実行環境に Android SDK の場所を示す `ANDROID_HOME` または `local.properties` の `sdk.dir` が設定されていないためビルドは開始できませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60144bb878832cba65d05a1a78bae1)